### PR TITLE
feature: allow vacuum disablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ actual cache time will always be lower or equal to this.
 *Default: 600*
 
 The number of seconds to wait between cache cleanup runs.
+
+A value of -1 disables cleanup. It means stale records won't be cleaned up so if you
+don't limit yourself to a fixed set of paths that is managed by this plugin you risk
+filling up your cache filesystem. But it avoids issue [#21](https://github.com/traefik/plugin-simplecache/issues/21)
 	
 #### Add Status Header (`addStatusHeader`)
 

--- a/cache.go
+++ b/cache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -34,6 +35,7 @@ const (
 	cacheHitStatus   = "hit"
 	cacheMissStatus  = "miss"
 	cacheErrorStatus = "error"
+	cleanupDisabled  = -1
 )
 
 type cache struct {
@@ -49,8 +51,8 @@ func New(_ context.Context, next http.Handler, cfg *Config, name string) (http.H
 		return nil, errors.New("maxExpiry must be greater or equal to 1")
 	}
 
-	if cfg.Cleanup <= 1 {
-		return nil, errors.New("cleanup must be greater or equal to 1")
+	if cfg.Cleanup <= 1 && cfg.Cleanup != cleanupDisabled {
+		return nil, fmt.Errorf("cleanup must be greater or equal to 1 or disabled %d", cleanupDisabled)
 	}
 
 	fc, err := newFileCache(cfg.Path, time.Duration(cfg.Cleanup)*time.Second)

--- a/cache_test.go
+++ b/cache_test.go
@@ -26,9 +26,14 @@ func TestNew(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "should error if cleanup <= 1",
+			name:    "should error if cleanup <= 1 and not -1",
 			cfg:     &Config{Path: os.TempDir(), MaxExpiry: 300, Cleanup: 1},
 			wantErr: true,
+		},
+		{
+			name:    "should not error if cleanup == -1",
+			cfg:     &Config{Path: os.TempDir(), MaxExpiry: 300, Cleanup: -1},
+			wantErr: false,
 		},
 		{
 			name:    "should be valid",
@@ -43,6 +48,9 @@ func TestNew(t *testing.T) {
 
 			if test.wantErr && err == nil {
 				t.Fatal("expected error on bad regexp format")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("did not expect error but got %s", err)
 			}
 		})
 	}

--- a/file.go
+++ b/file.go
@@ -37,7 +37,9 @@ func newFileCache(path string, vacuum time.Duration) (*fileCache, error) {
 		pm:   &pathMutex{lock: map[string]*fileLock{}},
 	}
 
-	go fc.vacuum(vacuum)
+	if vacuum > 0 * time.Second {
+		go fc.vacuum(vacuum)
+	}
 
 	return fc, nil
 }


### PR DESCRIPTION
The vacuum implementation is causing a leak on Traefik v3

By allowing to disable the vacuum process certain use cases can avoid the issues caused by a memory leak as detailed in #21 .