### PR TITLE
fix: websockets breaking

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -2,10 +2,13 @@
 package plugin_simplecache
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"time"
 
@@ -168,4 +171,19 @@ func (rw *responseWriter) Write(p []byte) (int, error) {
 func (rw *responseWriter) WriteHeader(s int) {
 	rw.status = s
 	rw.ResponseWriter.WriteHeader(s)
+}
+
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("%T is not a http.Hijacker", rw.ResponseWriter)
+	}
+
+	return hijacker.Hijack()
+}
+
+func (rw *responseWriter) Flush() {
+	if flusher, ok := rw.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
 }


### PR DESCRIPTION
Closes #23

I tested this using traefik local plugins and it seems to fix the web socket issue I was getting and can see messages get handled via the socket.

I've not very familiar with go and traefik plugin development  but I basically did the same as https://github.com/SchmitzDan/traefik-plugin-proxy-cookie/issues/3 and this commit https://github.com/SchmitzDan/traefik-plugin-proxy-cookie/pull/4/files