### PR TITLE
Add ConsiderUrlQuery flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,13 @@ The number of seconds to wait between cache cleanup runs.
 
 This determines if the cache status header `Cache-Status` will be added to the
 response headers. This header can have the value `hit`, `miss` or `error`.
+
+#### 	ConsiderUrlQuery (`considerUrlQuery`)
+
+*Default: false*
+
+This determines if a request URL's query parameters are used in the cache key. If
+this is set to `false`, the cached response for one request will be returned for
+subequent requests that differ only by their URL query parameters. If this is set
+to `true`, requests with different query parameters will have different cached
+responses stored.

--- a/cache.go
+++ b/cache.go
@@ -14,18 +14,20 @@ import (
 
 // Config configures the middleware.
 type Config struct {
-	Path            string `json:"path" yaml:"path" toml:"path"`
-	MaxExpiry       int    `json:"maxExpiry" yaml:"maxExpiry" toml:"maxExpiry"`
-	Cleanup         int    `json:"cleanup" yaml:"cleanup" toml:"cleanup"`
-	AddStatusHeader bool   `json:"addStatusHeader" yaml:"addStatusHeader" toml:"addStatusHeader"`
+	Path             string `json:"path" yaml:"path" toml:"path"`
+	MaxExpiry        int    `json:"maxExpiry" yaml:"maxExpiry" toml:"maxExpiry"`
+	Cleanup          int    `json:"cleanup" yaml:"cleanup" toml:"cleanup"`
+	AddStatusHeader  bool   `json:"addStatusHeader" yaml:"addStatusHeader" toml:"addStatusHeader"`
+	ConsiderUrlQuery bool   `json:"considerUrlQuery" yaml:"considerUrlQuery" toml:"considerUrlQuery"`
 }
 
 // CreateConfig returns a config instance.
 func CreateConfig() *Config {
 	return &Config{
-		MaxExpiry:       int((5 * time.Minute).Seconds()),
-		Cleanup:         int((5 * time.Minute).Seconds()),
-		AddStatusHeader: true,
+		MaxExpiry:        int((5 * time.Minute).Seconds()),
+		Cleanup:          int((5 * time.Minute).Seconds()),
+		AddStatusHeader:  true,
+		ConsiderUrlQuery: false,
 	}
 }
 
@@ -78,7 +80,7 @@ type cacheData struct {
 func (m *cache) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cs := cacheMissStatus
 
-	key := cacheKey(r)
+	key := cacheKey(m.cfg, r)
 
 	b, err := m.cache.Get(key)
 	if err == nil {
@@ -146,8 +148,12 @@ func (m *cache) cacheable(r *http.Request, w http.ResponseWriter, status int) (t
 	return expiry, true
 }
 
-func cacheKey(r *http.Request) string {
-	return r.Method + r.Host + r.URL.Path
+func cacheKey(cfg *Config, r *http.Request) string {
+	key := r.Method + r.Host + r.URL.Path
+	if !cfg.ConsiderUrlQuery {
+		return key
+	}
+	return key + "?" + r.URL.Query().Encode()
 }
 
 type responseWriter struct {

--- a/cache_test.go
+++ b/cache_test.go
@@ -56,7 +56,7 @@ func TestCache_ServeHTTP(t *testing.T) {
 		rw.WriteHeader(http.StatusOK)
 	}
 
-	cfg := &Config{Path: dir, MaxExpiry: 10, Cleanup: 20, AddStatusHeader: true}
+	cfg := &Config{Path: dir, MaxExpiry: 10, Cleanup: 20, AddStatusHeader: true, ConsiderUrlQuery: false}
 
 	c, err := New(context.Background(), http.HandlerFunc(next), cfg, "simplecache")
 	if err != nil {
@@ -69,7 +69,7 @@ func TestCache_ServeHTTP(t *testing.T) {
 	c.ServeHTTP(rw, req)
 
 	if state := rw.Header().Get("Cache-Status"); state != "miss" {
-		t.Errorf("unexprect cache state: want \"miss\", got: %q", state)
+		t.Errorf("unexpected cache state: want \"miss\", got: %q", state)
 	}
 
 	rw = httptest.NewRecorder()
@@ -77,7 +77,56 @@ func TestCache_ServeHTTP(t *testing.T) {
 	c.ServeHTTP(rw, req)
 
 	if state := rw.Header().Get("Cache-Status"); state != "hit" {
-		t.Errorf("unexprect cache state: want \"hit\", got: %q", state)
+		t.Errorf("unexpected cache state: want \"hit\", got: %q", state)
+	}
+
+	rw = httptest.NewRecorder()
+	// Check that the same request with a different URL query hits the same cache entry
+	c.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "http://localhost/some/path?queryParam=1", nil))
+
+	if state := rw.Header().Get("Cache-Status"); state != "hit" {
+		t.Errorf("unexpected cache state: want \"hit\", got: %q", state)
+	}
+
+}
+
+func TestCache_ServeHTTP_ConsiderUrlQuery(t *testing.T) {
+	dir := createTempDir(t)
+
+	next := func(rw http.ResponseWriter, req *http.Request) {
+		rw.Header().Set("Cache-Control", "max-age=20")
+		rw.WriteHeader(http.StatusOK)
+	}
+
+	cfg := &Config{Path: dir, MaxExpiry: 10, Cleanup: 20, AddStatusHeader: true, ConsiderUrlQuery: true}
+
+	c, err := New(context.Background(), http.HandlerFunc(next), cfg, "simplecache")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testUrl := "http://localhost/some/path"
+	req := httptest.NewRequest(http.MethodGet, testUrl, nil)
+	rw := httptest.NewRecorder()
+
+	c.ServeHTTP(rw, req) // Add response to the cache
+	rw = httptest.NewRecorder()
+	c.ServeHTTP(rw, req)
+
+	if state := rw.Header().Get("Cache-Status"); state != "hit" {
+		t.Errorf("unexpected cache state: want \"hit\", got: %q", state)
+	}
+
+	rw = httptest.NewRecorder()
+	c.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, testUrl+"?queryParam=1", nil))
+	if state := rw.Header().Get("Cache-Status"); state != "miss" {
+		t.Errorf("unexpected cache state: want \"miss\", got: %q", state)
+	}
+
+	rw = httptest.NewRecorder()
+	c.ServeHTTP(rw, httptest.NewRequest(http.MethodGet, testUrl+"?queryParam=2", nil))
+	if state := rw.Header().Get("Cache-Status"); state != "miss" {
+		t.Errorf("unexpected cache state: want \"miss\", got: %q", state)
 	}
 }
 


### PR DESCRIPTION
### Existing behavior
The existing `simplecache` code does not include URL query string parameters in the cache key. This means that a GET request to the same URL with different query strings will return the same cached response.

### Issue
I have a video management server project where an endpoint returns an image, and the user can set the desired size with the URL query (e.g. `http://my_server/image_endpoint?width=480`). The remote cameras are connected via a slow metered connection, so I want to cache responses. 

However, if the user requests: 
1. `http://my_server/image_endpoint?width=480`
2. And then, `http://my_server/image_endpoint?width=1920`, 
The 480px-wide image, cached for (1), is used as the cached response for (2), even though the user requested a 1920px-wide image. 

**Why not have the user provide a JSON payload with the desired image width instead of a URL parameter?**
The customer wants to easily access images by pasting a URL into their browser. They do not want to construct HTTP requests with payloads with CURL or similar tools.

### Suggested change in this MR 
This MR adds a `ConsiderUrlQuery` flag. In its default `false` state, existing behavior is preserved. If set to `true`, query parameters will be used in the cache key.

Perhaps in the future, it could be useful to provide a list of query string parameters to include/exclude from the cache key. However, I am new to this repo's conventions and would like to ensure I understand the maintainer's preferences before adding more changes.